### PR TITLE
Switch to main upstream Phoenix library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -229,6 +229,17 @@
         "snekfetch": "^3.6.4",
         "tweetnacl": "^1.0.0",
         "ws": "^4.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "doctrine": {
@@ -785,9 +796,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
+      "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -890,13 +901,10 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "phoenix-channels": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/phoenix-channels/-/phoenix-channels-1.0.0.tgz",
-      "integrity": "sha1-TeOno0J0g97/xJCNj+yscl2wbWo=",
-      "requires": {
-        "websocket": "^1.0.24"
-      }
+    "phoenix": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.4.2.tgz",
+      "integrity": "sha512-ykIhZbqdmgoUaME8ArXWHMuVvTiV6vXQktqPPM2n082bGGVFnIhjEVk/PCKYrRNhfmWTtTkci8VknG4qwksy+w=="
     },
     "pluralize": {
       "version": "7.0.0",
@@ -1266,15 +1274,6 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
-      }
-    },
-    "ws": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-      "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0"
       }
     },
     "yaeti": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "discord.js": "^11.4.2",
     "dotenv": "^6.2.0",
     "escape-string-regexp": "^1.0.5",
-    "phoenix-channels": "^1.0.0",
-    "uuid": "^3.3.2"
+    "phoenix": "^1.4.2",
+    "uuid": "^3.3.2",
+    "websocket": "^1.0.28"
   },
   "devDependencies": {
     "eslint": "^5.12.1",

--- a/src/reticulum.js
+++ b/src/reticulum.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
+const WebSocket = require('websocket').w3cwebsocket;
 const https = require('https');
-const phoenix = require("phoenix-channels");
+const phoenix = require("phoenix");
 const uuid = require("uuid");
 
 // The URL for the scene used if users create a new room but don't specify a scene.
@@ -128,6 +129,7 @@ class ReticulumClient {
   constructor(hostname) {
     this.hostname = hostname;
     this.socket = new phoenix.Socket(`wss://${hostname}/socket`, {
+      transport: WebSocket,
       params: { session_id: uuid() }
     });
   }


### PR DESCRIPTION
It turns out that the upstream library seems to be Node-compatible now as long as we explicitly override the transport. This is particularly nice because now the Reticulum helper code could be shared in the future between this and Hubs, taking the Phoenix library as a dependency.