### PR TITLE
Small fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,15 +139,10 @@ function establishBindings(reticulumCh, discordCh, webhook, state) {
       const msg = ts(`Relaying message of type ${type} from ${whom} (${id}) via ${state.id} to channel ${discordCh.id}: %j`);
       console.debug(msg, body);
     }
-    if (type === "spawn") {
-      webhook.send(body.src, { username: whom });
-    } else if (type === "chat") {
+    if (type === "chat") {
       webhook.send(body, { username: whom });
     } else if (type === "media") {
-      // don't bother with media that is "boring", i.e. vendored by us, like chats, ducks, avatars, pens
-      if (!body.src.startsWith("https://asset-bundles-prod.reticulum.io")) {
-        webhook.send(body.src, { username: whom });
-      }
+      webhook.send(body.src, { username: whom });
     }
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ async function start() {
           if (VERBOSE) {
             console.debug(ts(`Relaying chat message via channel ${discordCh.id} to hub ${hubId}.`));
           }
-          binding.reticulumCh.sendMessage(msg.author.username, msg.content);
+          binding.reticulumCh.sendMessage(msg.author.username, msg.cleanContent);
         }
         return;
       }


### PR DESCRIPTION
Self-explanatory. We don't need the media spawning URL restriction anymore because the fact that someone pinned the object is enough indication (in our theory) that they wanted to broadcast it, even if it was, like, a duck.