### PR TITLE
Deduplicate media broadcast within the same minute

### DIFF
--- a/src/reticulum.js
+++ b/src/reticulum.js
@@ -79,7 +79,7 @@ class ReticulumChannel extends EventEmitter {
     });
 
     this.channel.on("pin", (data) => {
-      const { object_id, gltf_node, pinned_by } = data;
+      const { gltf_node, pinned_by } = data;
       if (gltf_node &&
           gltf_node.extensions &&
           gltf_node.extensions.HUBS_components &&
@@ -148,7 +148,7 @@ class ReticulumClient {
   async _request(method, path, payload) {
     const endpoint = `https://${this.hostname}/api/v1/${path}`;
     const payloadJson = JSON.stringify(payload);
-    const headers = { 
+    const headers = {
       "content-type": "application/json",
       "x-ret-bot-access-key": process.env.RETICULUM_BOT_ACCESS_KEY,
       "content-length": Buffer.byteLength(payloadJson)

--- a/src/topic.js
+++ b/src/topic.js
@@ -52,7 +52,7 @@ class TopicManager {
     } catch (e) { /* not a valid URL */ }
 
     return null;
-  };
+  }
 
   matchScene(topic) {
     const [sceneUrlStr, _host] = (topic || "").match(this.sceneRe) || [];


### PR DESCRIPTION
This will tidy up the log in some common cases. I really don't like making the broadcast behavior more mysterious, because it's going to seem like a bug if people don't know what's going on, but this is the price we need to pay if we want pinning to === broadcasting.