### PR TITLE
Fix scene URL identification code

### DIFF
--- a/src/topic.js
+++ b/src/topic.js
@@ -55,7 +55,7 @@ class TopicManager {
   }
 
   matchScene(topic) {
-    const [sceneUrlStr, _host] = (topic || "").match(this.sceneRe) || [];
+    const [sceneUrlStr, _host] = (topic || "").match(this.sceneUrlRe) || [];
     if (!sceneUrlStr) {
       return null;
     }
@@ -64,10 +64,10 @@ class TopicManager {
       // check for scene URL: https://hubs.mozilla.com/scenes/a0b1c2d/foo-bar
       const pathElements = splitPath(sceneUrl.pathname);
       if (pathElements.length >= 1) {
-        const sceneId = pathElements[0];
+        const sceneId = pathElements[1]; // pathElements[0] === "scenes"
         if (sceneId != null && SCENE_ID_RE.test(sceneId)) {
-          if (pathElements.length >= 2) {
-            const sceneSlug = pathElements[1];
+          if (pathElements.length >= 3) {
+            const sceneSlug = pathElements[2];
             return { sceneUrl, sceneId, sceneSlug };
           } else {
             return { sceneUrl, sceneId };

--- a/tests/topic.js
+++ b/tests/topic.js
@@ -11,7 +11,7 @@ test('Hubs URLs are correctly added to and removed from topics', function(t) {
   t.end();
 });
 
-test('Hubs URLs are detected in channel topics', function(t) {
+test('Hubs URLs are correctly identified', function(t) {
   var tm = new TopicManager(["foo", "bar.mozilla.com", "hubs.local:8080", "localhost"]);
   // path form: hub IDs must be exactly 7 characters and followed by an optional slug
   t.equal(tm.matchHub("https://foo/0123456/").hubId, "0123456");
@@ -28,5 +28,16 @@ test('Hubs URLs are detected in channel topics', function(t) {
   t.equal(tm.matchHub("https://hubs.local:443/hub.html"), null);
   t.equal(tm.matchHub("http://localhost/hub.html?hub_id=foobar1").hubId, "foobar1");
   t.equal(tm.matchHub("https://localhots/hub.html?hub_id=foobar1"), null);
+  t.end();
+});
+
+test('Scene URLs are correctly identified', function(t) {
+  var tm = new TopicManager(["hubs.mozilla.com", "hubs.local:8080"]);
+  // scene IDs must be exactly 7 characters and followed by an optional slug
+  t.equal(tm.matchScene("http://foo/scenes/blah-blah-blah"), null);
+  t.equal(tm.matchScene("https://hubs.mozilla.com/scenes/d0gf00d/ponies").sceneId, "d0gf00d");
+  t.equal(tm.matchScene("https://hubs.mozilla.com/d0gf00d/ponies"), null);
+  t.equal(tm.matchScene("https://hubs.local:8080/scenes/wwwwwww").sceneId, "wwwwwww");
+  t.equal(tm.matchScene("https://hubs.local:8080/scenes/wwwwwwww"), null);
   t.end();
 });


### PR DESCRIPTION
This fix causes `!hubs create [sceneUrl] [name]` to start working again.

Resolves https://github.com/MozillaReality/hubs-discord-bot/issues/13.