### PR TITLE
Make webhook stuff harder to screw up

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -13,7 +13,8 @@ RETICULUM_BOT_ACCESS_KEY=
 HUBS_HOSTS=localhost,hubs.local
 
 # The name of the Discord webhook that the Hubs bot tries to post messages using. If this webhook
-# doesn't exist, it will use the first one in the list for the channel. If none exist, the bot won't work.
+# doesn't exist, it will use the first one in the list for the channel. If none exist, the bot won't
+# bridge chat from Hubs through to Discord.
 HUBS_HOOK=Hubs
 
 # The shard ID for this client. (0 if you aren't using multiple shards.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,26 +220,14 @@
       "dev": true
     },
     "discord.js": {
-      "version": "11.4.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.4.2.tgz",
-      "integrity": "sha512-MDwpu0lMFTjqomijDl1Ed9miMQe6kB4ifKdP28QZllmLv/HVOJXhatRgjS8urp/wBlOfx+qAYSXcdI5cKGYsfg==",
+      "version": "github:discordjs/discord.js#923c945b4bcacebafcd5e0210b485dfb702558c6",
+      "from": "github:discordjs/discord.js#11.4-dev",
       "requires": {
         "long": "^4.0.0",
         "prism-media": "^0.0.3",
         "snekfetch": "^3.6.4",
         "tweetnacl": "^1.0.0",
-        "ws": "^4.0.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
-          }
-        }
+        "ws": "^6.0.0"
       }
     },
     "doctrine": {
@@ -1002,11 +990,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1274,6 +1257,14 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "ws": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
       }
     },
     "yaeti": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "discord.js": "^11.4.2",
+    "discord.js": "github:discordjs/discord.js#11.4-dev",
     "dotenv": "^6.2.0",
     "escape-string-regexp": "^1.0.5",
     "phoenix": "^1.4.2",


### PR DESCRIPTION
Now:

- The bot will let you know if you bridge a room without having a webhook configured, under the presumption that you don't want that as an ongoing state of affairs.
- The bot will notice if you add or remove a webhook for it to use while it's already bridging.
- If you don't have a webhook for a bridged room at any given time, then everything that doesn't require a webhook (i.e. everything but outgoing stuff from Hubs) will still work.

This should make it less confusing about what the state of affairs is with regard to your webhook setup.