### PR TITLE
Bridge Discord image attachments to Hubs chat

### DIFF
--- a/src/reticulum.js
+++ b/src/reticulum.js
@@ -120,8 +120,8 @@ class ReticulumChannel extends EventEmitter {
   }
 
   // Sends a chat message that Hubs users will see in the chat box.
-  sendMessage(name, body) {
-    this.channel.push("message", { type: "chat", from: name, body }); // no ack is expected
+  sendMessage(name, kind, body) {
+    this.channel.push("message", { type: kind, from: name, body }); // no ack is expected
   }
 
 }


### PR DESCRIPTION
JPEGs, GIFs, and PNGs provided as attachments in Discord will now appear in bridged Hubs chat. Depends on https://github.com/mozilla/hubs/pull/1189, which adds support for presenting `type: "image"` messages in Hubs. Resolves #19.