### PR TITLE
Always broadcast Hubs photos to Discord

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,9 @@ function subscribeToEvents(binding) {
       }
       mediaBroadcasts[body.src] = timestamp;
       webhook.send(body.src, { username: whom });
+    } else if (type === "photo") {
+      // we like to just broadcast all photos, without waiting for anyone to pin them
+      webhook.send(body.src, { username: whom });
     }
   });
 }


### PR DESCRIPTION
Resolves #21. Now all photos taken in Hubs are immediately bridged to Discord.