### PR TITLE
Fix session ID management to be more correct

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ async function trySetTopic(discordCh, newTopic) {
   });
 }
 
-function subscribeToEvents(binding) {
+function establishBridge(binding) {
   const { reticulumCh, discordCh, hubState: state } = binding;
   console.info(ts(`Hubs room ${state.id} bridged to Discord channel ${discordCh.id}.`));
 
@@ -206,7 +206,7 @@ async function start() {
           const webhook = await getHubsWebhook(chan);
           const state = new HubState(hubUrl.host, hub.hub_id, hub.name, hub.slug, new Date());
           const binding = bindings.associate(reticulumCh, chan, webhook, state, hubUrl.host);
-          subscribeToEvents(binding);
+          establishBridge(binding);
         } catch (e) {
           console.error(ts(`Failed to bridge to ${hubUrl}:`), e);
         }
@@ -251,7 +251,7 @@ async function start() {
             const webhook = await getHubsWebhook(newChannel);
             const state = new HubState(currHubUrl.host, hub.hub_id, hub.name, hub.slug, new Date());
             const binding = bindings.associate(reticulumCh, newChannel, webhook, state, currHubUrl.host);
-            subscribeToEvents(binding);
+            establishBridge(binding);
             if (webhook != null) {
               await newChannel.send(`<#${newChannel.id}> bridged to ${currHubUrl}.`);
             } else {

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ async function trySetTopic(discordCh, newTopic) {
 
 function subscribeToEvents(binding) {
   const { reticulumCh, discordCh, hubState: state } = binding;
-  console.info(ts(`Hubs room ${state.id} bound to Discord channel ${discordCh.id}; joining.`));
+  console.info(ts(`Hubs room ${state.id} bridged to Discord channel ${discordCh.id}.`));
 
   const presenceRollups = new PresenceRollups();
   const mediaBroadcasts = {}; // { url: timestamp }
@@ -200,13 +200,15 @@ async function start() {
       const { hubUrl, hubId } = topicManager.matchHub(chan.topic) || {};
       if (hubUrl) {
         try {
-          const { hub, subscription } = await reticulumClient.subscribeToHub(hubId, chan.name);
+          const reticulumCh = reticulumClient.channelForHub(hubId, chan.name);
+          reticulumCh.on("connect", id => { console.info(ts(`Connected to Hubs room ${hubId} with session ID ${id}`)); });
+          const hub = (await reticulumCh.connect()).hubs[0];
           const webhook = await getHubsWebhook(chan);
           const state = new HubState(hubUrl.host, hub.hub_id, hub.name, hub.slug, new Date());
-          const binding = bindings.associate(subscription, chan, webhook, state, hubUrl.host);
+          const binding = bindings.associate(reticulumCh, chan, webhook, state, hubUrl.host);
           subscribeToEvents(binding);
         } catch (e) {
-          console.error(ts(`Failed to subscribe to ${hubUrl}:`), e);
+          console.error(ts(`Failed to bridge to ${hubUrl}:`), e);
         }
       }
     });
@@ -243,10 +245,12 @@ async function start() {
             await newChannel.send(`<#${newChannel.id}> no longer bridged to <${hubState.url}>.`);
           }
           if (currHubId) {
-            const { hub, subscription } = await reticulumClient.subscribeToHub(currHubId, newChannel.name);
+            const reticulumCh = reticulumClient.channelForHub(currHubId, newChannel.name);
+            reticulumCh.on("connect", id => { console.info(ts(`Connected to Hubs room ${currHubId} with session ID ${id}`)); });
+            const hub = (await reticulumCh.connect()).hubs[0];
             const webhook = await getHubsWebhook(newChannel);
             const state = new HubState(currHubUrl.host, hub.hub_id, hub.name, hub.slug, new Date());
-            const binding = bindings.associate(subscription, newChannel, webhook, state, currHubUrl.host);
+            const binding = bindings.associate(reticulumCh, newChannel, webhook, state, currHubUrl.host);
             subscribeToEvents(binding);
             if (webhook != null) {
               await newChannel.send(`<#${newChannel.id}> bridged to ${currHubUrl}.`);
@@ -255,7 +259,7 @@ async function start() {
             }
           }
         } catch (e) {
-          console.error(ts(`Failed to update channel bridging from ${prevHubId} to ${currHubId}:`), e);
+          console.error(ts(`Failed to update bridge from ${prevHubId} to ${currHubId}:`), e);
         }
       }
     });

--- a/src/reticulum.js
+++ b/src/reticulum.js
@@ -209,9 +209,10 @@ class ReticulumClient {
     return this._request("POST", "hub_bindings", payload);
   }
 
-  // Subscribes to the Phoenix channel for the given hub ID and resolves to a `{ hub, subscription }` pair,
-  // where `subscription` is the Phoenix channel object and `hub` is the hub metadata from Reticulum.
-  // The channel name is used to inform other users which Discord channel we're bridging to.
+  // Returns a channel object for the given Hub room's Phoenix channel.
+  //
+  // The channel name is used when joining the channel as part of our presence metadata to inform other users
+  // which Discord channel we're bridging to.
   channelForHub(hubId, channelName) {
     const payload = {
       context: { mobile: false, hmd: false, discord: channelName },


### PR DESCRIPTION
The previous implementation handled expiry incorrectly and was very confusing to think about. This version is much simpler and seems more obviously correct. The only remaining question is that of race conditions related to the time between you "having" a session ID (socket connection) and "knowing about" the session ID (channel join), and we're pretending those don't matter for now.

For simplicity, we now make no effort to reuse the session ID between reconnects, reflecting the reality that session IDs are not currently intended to actually be reliably reused by a user over time.

Note that the store of session IDs belonging to the bot is global, which actually seems "more correct" in the case that you have multiple `ReticulumClient` objects hanging around -- you would prefer the bot not to respond to messages from other copies of itself. It would be better for it to persist, because then the bot would know about its old session IDs if it restarted and rejoined the same Hubs room. When we implement a persistent data store it should probably go in there.

Also clean up logging to be more helpful and create log entries on reconnects.

