### PR TITLE
Fix up help text

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -349,10 +349,10 @@ async function start() {
     });
   });
 
-  const HELP_TEXT = "Hi! I'm the Hubs bot. I connect Discord channels with rooms on Hubs (https://hubs.mozilla.com/). " +
-        "You can use the following commands:\n\n" +
+  const HELP_TEXT = "Hi! I'm the Hubs bot. I connect Discord channels with rooms on Hubs (https://hubs.mozilla.com/). Any room with its URL in a channel topic will bridge chat and media back and forth between the channel and the room." +
+        "You can also use the following commands:\n\n" +
         "🦆 `!hubs create` - Creates a default Hubs room and puts its URL into the channel topic. " +
-        "A room URL in the channel topic will be bridged between Hubs and Discord.\n" +
+        "Rooms created with `!hubs create` will inherit moderation permissions from this Discord channel and only allow Discord users in this channel to join the room.\n" +
         "🦆 `!hubs create [scene URL] [name]` - Creates a new room with the given scene and name, and puts its URL into the channel topic.\n" +
         "🦆 `!hubs stats` - Shows some summary statistics about room usage.\n" +
         "🦆 `!hubs status` - Shows general information about the Hubs integration with the current Discord channel.\n" +

--- a/src/index.js
+++ b/src/index.js
@@ -354,6 +354,7 @@ async function start() {
         "🦆 `!hubs create` - Creates a default Hubs room and puts its URL into the channel topic. " +
         "A room URL in the channel topic will be bridged between Hubs and Discord.\n" +
         "🦆 `!hubs create [scene URL] [name]` - Creates a new room with the given scene and name, and puts its URL into the channel topic.\n" +
+        "🦆 `!hubs stats` - Shows some summary statistics about room usage.\n" +
         "🦆 `!hubs status` - Shows general information about the Hubs integration with the current Discord channel.\n" +
         "🦆 `!hubs remove` - Removes the room URL from the topic and stops bridging this Discord channel with Hubs.\n" +
         "🦆 `!hubs users` - Lists the users currently in the Hubs room bridged to this channel.\n\n" +


### PR DESCRIPTION
This adds a note about `!hubs stats` and provides some much-needed interactive documentation about what is going on with permission-bound rooms.