### PR TITLE
Log guild ID in non-verbose mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,8 @@ function ts(str) {
 function formatDiscordCh(discordCh) {
   if (VERBOSE && discordCh.guild && discordCh.name) {
     return `${discordCh.guild.name}/#${discordCh.name} (${discordCh.id})`;
+  } else if (discordCh.guild) {
+    return `${discordCh.guild.id}/${discordCh.id}`;
   } else {
     return discordCh.id;
   }


### PR DESCRIPTION
Generally useful for debugging, and it might be nice someday for people running the bot to have some idea how many distinct guilds it's talking to.