### PR TITLE
Multibridging fixes

### DIFF
--- a/src/bindings.js
+++ b/src/bindings.js
@@ -4,7 +4,8 @@ const { PresenceRollups } = require("./presence-rollups.js");
 // Represents our knowledge about a hub on a particular Reticulum server.
 class HubState {
 
-  constructor(host, id, name, slug, ts) {
+  constructor(reticulumCh, host, id, name, slug, ts) {
+    this.reticulumCh = reticulumCh;
     this.host = host;
     this.id = id;
     this.name = name;
@@ -25,7 +26,7 @@ class HubState {
 class ChannelBindings {
 
   constructor() {
-    this.hubsByChannel = {};
+    this.hubsByChannel = {}; // channel ID: hub ID or null
     this.bindingsByHub = {};
   }
 
@@ -37,9 +38,9 @@ class ChannelBindings {
   }
 
   // Adds a new entry to the mapping.
-  associate(reticulumCh, discordCh, webhook, hubState, host) {
+  associate(discordCh, webhook, hubState) {
     this.hubsByChannel[discordCh.id] = hubState.id;
-    return this.bindingsByHub[hubState.id] = { hubState, host, discordCh, reticulumCh, webhook };
+    return this.bindingsByHub[hubState.id] = { hubState, discordCh, webhook };
   }
 
 }

--- a/src/bridges.js
+++ b/src/bridges.js
@@ -22,27 +22,27 @@ class HubState {
 
 }
 
-// Represents all state related to the mapping between Discord channels and Hubs rooms.
-class ChannelBindings {
+// Represents all state related to the bridging between Discord channels and Hubs rooms.
+class ChannelBridges {
 
   constructor() {
-    this.hubsByChannel = {}; // channel ID: hub ID or null
-    this.bindingsByHub = {};
+    this.hubsByChannel = {};
+    this.bridgesByHub = {};
   }
 
   // Removes an entry from the mapping.
   dissociate(hubId) {
-    const binding = this.bindingsByHub[hubId];
-    delete this.hubsByChannel[binding.discordCh.id];
-    delete this.bindingsByHub[hubId];
+    const bridge = this.bridgesByHub[hubId];
+    delete this.hubsByChannel[bridge.discordCh.id];
+    delete this.bridgesByHub[hubId];
   }
 
   // Adds a new entry to the mapping.
   associate(discordCh, webhook, hubState) {
     this.hubsByChannel[discordCh.id] = hubState.id;
-    return this.bindingsByHub[hubState.id] = { hubState, discordCh, webhook };
+    return this.bridgesByHub[hubState.id] = { hubState, discordCh, webhook };
   }
 
 }
 
-module.exports = { ChannelBindings, HubState };
+module.exports = { ChannelBridges, HubState };


### PR DESCRIPTION
This refactors the representation of how hub/channel bridges are tracked so that we can efficiently and correctly support bringing hubs to multiple channels using a single instance of the bot. Here is how it works now:

1. `Bridges` is a mutable bi-directional map between in-memory hub state (incl. the Phoenix channel object for the hub) and the set of Discord channel handles it's currently bridged to.
2. When we decide that a channel should be bridged:
  a. If the hub in the channel is not yet bridged anywhere, join the Phoenix channel, set initial state, and wire up events on it.
  b. Make an entry in the mapping.
3. When we decide that a channel should be un-bridged:
  a. Remove the entry in the mapping.
  b. If the hub is no longer bridged to any channels, leave the Phoenix channel and tear down all state for the hub.
4. When something interesting happens in a hub, examine the current collection of bridges, and broadcast as necessary to all of the channels involved.

Note that activity in Discord channels never gets sent to other Discord channels -- only to the hub.

There's still an outstanding bug with this implementation -- we need to update the Phoenix presence metadata for the Hubs bot in each channel it's in when a new bridge is created to have the new Discord channel name in it.