### PR TITLE
Refactor stats and presence rollup initialization

### DIFF
--- a/src/presence-rollups.js
+++ b/src/presence-rollups.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events');
 
 // Data structure for tracking the series of arrivals/departures in a hub and rolling it up
-// into a useful stream of Discord notifications. When new arrivals or departures happen, either
+// into a useful stream of notifications. When new arrivals or departures happen, either
 // a new notification will be produced, or the most recent notification will be amended. If
 // a user renames themselves rapidly after arriving, the arrival will be amended to have their
 // new name.
@@ -41,6 +41,12 @@ class PresenceRollups extends EventEmitter {
       // The duration for which we wait for someone to rejoin before we announce their departure.
       departRejoinPatienceMs: 15 * 1000,
     }, options);
+  }
+
+  subscribeToChannel(reticulumCh) {
+    reticulumCh.on('join', (ts, id, kind, whom) => { this.arrive(id, whom, ts); });
+    reticulumCh.on('leave', (ts, id, kind, whom) => { this.depart(id, whom, ts); });
+    reticulumCh.on('renameuser', (ts, id, kind, prev, curr) => { this.rename(id, prev, curr, ts); });
   }
 
   latest() {

--- a/src/reticulum.js
+++ b/src/reticulum.js
@@ -43,15 +43,15 @@ class ReticulumChannel extends EventEmitter {
         // this guy was already in the lobby or room, notify iff their name changed or they moved between the lobby and room
         const previous = curr.metas[curr.metas.length - 1];
         if (previous.profile && mostRecent.profile && previous.profile.displayName !== mostRecent.profile.displayName) {
-          this.emit('renameuser', id, mostRecent.presence, previous.profile.displayName, mostRecent.profile.displayName);
+          this.emit('renameuser', Date.now(), id, mostRecent.presence, previous.profile.displayName, mostRecent.profile.displayName);
         }
         if (previous.presence === "lobby" && mostRecent.presence && previous.presence !== mostRecent.presence) {
-          this.emit('moved', id, mostRecent.presence, previous.presence);
+          this.emit('moved', Date.now(), id, mostRecent.presence, previous.presence);
         }
         return;
       }
       // this guy was not previously present, notify for a join
-      this.emit('join', id, mostRecent.presence, mostRecent.profile.displayName);
+      this.emit('join', Date.now(), id, mostRecent.presence, mostRecent.profile.displayName);
     });
 
     this.presence.onLeave((id, curr, p) => {
@@ -62,16 +62,16 @@ class ReticulumChannel extends EventEmitter {
       if (curr != null && curr.metas != null && curr.metas.length > 0) {
         return; // this guy is still in the lobby or room, don't notify yet
       }
-      this.emit('leave', id, mostRecent.presence, mostRecent.profile.displayName);
+      this.emit('leave', Date.now(), id, mostRecent.presence, mostRecent.profile.displayName);
     });
 
     this.channel.on("hub_refresh", ({ session_id, stale_fields, hubs }) => {
       const sender = this.getName(session_id);
       if (stale_fields.includes('scene')) {
-        this.emit('rescene', session_id, sender, hubs[0].scene);
+        this.emit('rescene', Date.now(), session_id, sender, hubs[0].scene);
       }
       if (stale_fields.includes('name')) { // for some reason it doesn't say that the slug is stale, but it is
-        this.emit('renamehub', session_id, sender, hubs[0].name, hubs[0].slug);
+        this.emit('renamehub', Date.now(), session_id, sender, hubs[0].name, hubs[0].slug);
       }
     });
 
@@ -83,7 +83,7 @@ class ReticulumChannel extends EventEmitter {
           gltf_node.extensions.HUBS_components.media &&
           gltf_node.extensions.HUBS_components.media.src) {
         const sender = this.getName(pinned_by);
-        this.emit('message', null, sender, "media", { src: gltf_node.extensions.HUBS_components.media.src });
+        this.emit('message', Date.now(), null, sender, "media", { src: gltf_node.extensions.HUBS_components.media.src });
       }
     });
 
@@ -93,7 +93,7 @@ class ReticulumChannel extends EventEmitter {
         return;
       }
       const sender = from || this.getName(session_id);
-      this.emit('message', session_id, sender, type, body);
+      this.emit('message', Date.now(), session_id, sender, type, body);
     });
 
     const data = await new Promise((resolve, reject) => {
@@ -102,7 +102,7 @@ class ReticulumChannel extends EventEmitter {
         .receive("timeout", reject)
         .receive("ok", data => { // this "ok" handler will be called on reconnects as well
 
-          this.emit('connect', data.session_id);
+          this.emit('connect', Date.now(), data.session_id);
           // note that it's kind of inherently strange that session IDs are associated with our socket on the
           // server, but we get them out only from channel join messages, causing this code to be in a weird
           // place. roll with it now i guess

--- a/src/stats.js
+++ b/src/stats.js
@@ -10,6 +10,12 @@ class HubStats {
     this.timeline = [];
   }
 
+  subscribeToChannel(reticulumCh) {
+    reticulumCh.on('join', (ts, id, kind) => { if (kind === "room") { this.arrive(ts); } });
+    reticulumCh.on('moved', (ts, id, kind) => { if (kind === "room") { this.arrive(ts); } });
+    reticulumCh.on('leave', (ts, id, kind) => { if (kind === "room") { this.depart(ts); } });
+  }
+
   // Marks the arrival of N new users.
   arrive(timestamp, n) {
     n = (n != null) ? n : 1;


### PR DESCRIPTION
This is pursuant to making sure that the Reticulum-related functionality is decoupled from the Discord-related functionality, so that it's easy to reuse code in e.g. a future Slack bot, or in Hubs or Spoke.