### PR TITLE
Disable @everyone and @here bridging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -320,7 +320,8 @@ async function start() {
     shardId,
     shardCount,
     messageCacheMaxSize: 1, // we have no use for manipulating historical messages
-    disabledEvents: DISABLED_EVENTS
+    disabledEvents: DISABLED_EVENTS,
+    disableEveryone: true
   });
 
   await connectToDiscord(discordClient, process.env.TOKEN);


### PR DESCRIPTION
What it says on the tin. If we really cared, we could look at the Discord permissions to see whether someone is allowed to use these @ s, but it's kind of weird anyway to send them through the bridge in my opinion so I would just as soon not.

Note that Hubs users can still construct @ notifications to channels or people by embedding their ID into a chat message in Hubs. That seems fine, if they have some weird reason to bother to do it.