### PR TITLE
Fix a bug for bridges where people already present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -351,7 +351,16 @@ async function connectToHub(reticulumClient, discordChannels, host, hubId) {
     stats.arrive(Date.now(), nRoomOccupants);
   }
   stats.subscribeToChannel(reticulumCh);
-  presenceRollups.subscribeToChannel(reticulumCh);
+
+  // wait until after the first sync, because we don't want to take action related to users who were already here
+  let initialSync = false;
+  reticulumCh.on("sync", () => {
+    if (!initialSync) {
+      initialSync = true;
+      presenceRollups.subscribeToChannel(reticulumCh);
+    }
+  });
+
   return new HubState(reticulumCh, host, resp.hub_id, resp.name, resp.slug, new Date(), stats, presenceRollups);
 }
 


### PR DESCRIPTION
This bug meant that if people were already in a hub when a bridge is established, and then someone quickly joins within the presence rollup window for arrivals, the bot would incorrectly want to make an "update" of the existing message for the arrival instead of a "new" message.