### PR TITLE
Fix a bug breaking bot permission prompting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,7 @@ async function tryPin(discordCh, message) {
 // Sets the topic to something new, or complains if we don't have "manage channel" permissions.
 async function trySetTopic(discordCh, newTopic) {
   try {
-    return discordCh.setTopic(newTopic);
+    return await discordCh.setTopic(newTopic);
   } catch(e) {
     if (!(e instanceof discord.DiscordAPIError)) {
       throw e;


### PR DESCRIPTION
This fixes the bug Greg noticed, where the bot stopped producing the "reminder error" when it tries to change the topic but can't do so because of a lack of permissions.