### PR TITLE
Bridge camera videos from Hubs->Discord

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,8 +307,8 @@ async function establishBridging(hubState, bridges) {
         webhook.send(body, { username: whom });
       } else if (type === "media") {
         webhook.send(body.src, { username: whom });
-      } else if (type === "photo") {
-        // we like to just broadcast all photos, without waiting for anyone to pin them
+      } else if (type === "photo" || type == "video") {
+        // we like to just broadcast all camera photos and videos, without waiting for anyone to pin them
         webhook.send(body.src, { username: whom });
       }
     }


### PR DESCRIPTION
This specifically bridges the videos you take with the Hubs camera tool, just like pictures that you take with the Hubs camera tool are bridged.

We don't bridge videos that you post from Discord into Hubs, because unlike images, we don't currently have a mechanism to take a thumbnail of the video and put it into chat, so it's not so easy to do it.