### PR TITLE
Parse dates using moment default timezone

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -753,7 +753,7 @@ async function start() {
           }
         } else { // !hubs notify set [date/time descriptor]
           const descriptor = args.slice(3).join(" ");
-          const when = moment(new Date(descriptor));
+          const when = moment(descriptor);
           if (!when.isValid()) {
             return discordCh.send("Sorry, I can't tell what time you are trying to tell me :(  I can read any time that Javascript's `Date.parse` knows how to read: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse");
           }

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -46,7 +46,7 @@ class NotificationManager extends EventEmitter {
   start() {
     const rule = new schedule.RecurrenceRule(null, null, null, null, null, null, 0);
     return schedule.scheduleJob(rule, (date) => {
-      const now = moment(date);
+      const now = moment.utc(date);
       for (const [ts, msgs] of this.data.entries()) {
         if (ts.isSame(now, "minute")) {
           this.data.delete(ts);


### PR DESCRIPTION
The difference here is that the `Date` constructor assumes inputs are your machine-local time when the timezone is not specified, whereas `moment` will use the configured timezone. Otherwise, it delegates to the `Date` constructor for the parsing.

Using this makes `moment` produce an angry warning telling me not to parse random strings and to use a format string instead, but that's fine. I love parsing random strings! The user will see immediately if it parsed out the wrong date.

(In the future we should probably be more restrictive.)