### PR TITLE
Check for and recommend READ_MESSAGE_HISTORY perm

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The bot requires several permissions in order to work:
 - "Send messages," "Read messages," and "Embed links" are necessary in order to bridge between the Hubs room that is linked to a channel and the messages that are sent within the channel on Discord.
 - "Manage webhooks" is necessary in order for the bot to find and use a webhook for bridging chat.
 - "Manage channels" is necessary in order for the bot to set the channel topic and bridge chat. **Note:** We do not ask for this permission globally when you add the bot to your server, instead we recommend you grant this permission to the bot in specific groups or channels.
-- "Manage messages" is necessary in order for the bot to pin notification messages. Like "manage channels", you should probably grant this for specific groups and channels.
+- "Manage messages" and "read message history" are necessary in order for the bot to pin notification messages. Like "manage channels", you should probably grant these for specific groups and channels.
 
 You can and should assign these on a channel-by-channel basis to the bot role after adding the bot to your guild.
 

--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,7 @@ async function tryPin(discordCh, message) {
     if (!(e instanceof discord.DiscordAPIError)) {
       throw e;
     } else {
-      message.edit("Sorry, but you'll need to give me \"manage messages\" permission, or else I won't be able to pin messages for notifications.");
+      message.edit("Sorry, but you'll need to give me \"manage messages\" and \"read message history\" permissions, or else I won't be able to pin messages for notifications.");
       return null;
     }
   }
@@ -477,7 +477,11 @@ async function start() {
         // evaluate permissions as a kind of short-circuiting because asking for pinned messages is slow
         // and it sucks to have to do it on literally every random channel in a server that the bot can read
         const perms = discordCh.permissionsFor(discordClient.user);
-        if (perms.has(discord.Permissions.FLAGS.MANAGE_MESSAGES)) {
+        if (perms.has([
+          discord.Permissions.FLAGS.MANAGE_MESSAGES,
+          discord.Permissions.FLAGS.READ_MESSAGES,
+          discord.Permissions.FLAGS.READ_MESSAGE_HISTORY
+        ])) {
           const pins = await discordCh.fetchPinnedMessages();
           const notifications = pins.filter(msg => {
             return msg.author.id === discordClient.user.id && NotificationManager.parseTimestamp(msg).isValid();


### PR DESCRIPTION
If the bot doesn't have this permission, it won't be able to look at old pinned notification messages, so the notifications may not fire (if e.g. the bot has to restart in between when you create the notification and when it fires.)