### PR TITLE
Upgrade Node to 12.9

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -7,7 +7,7 @@ pkg_description="Discord bot for Hubs by Mozilla"
 
 pkg_deps=(
   core/coreutils
-  core/node/11.2.0
+  core/node/12.9.0
 )
 
 pkg_build_deps=(

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,8 +289,8 @@
       "dev": true
     },
     "erlpack": {
-      "version": "github:discordapp/erlpack#674ebfd3439ba4b7ce616709821d27630f7cdc61",
-      "from": "github:discordapp/erlpack",
+      "version": "github:hammerandchisel/erlpack#5d0064f9e106841e1eead711a6451f99b0d289fd",
+      "from": "github:hammerandchisel/erlpack",
       "requires": {
         "bindings": "^1.5.0",
         "nan": "^2.14.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bufferutil": "^4.0.1",
     "discord.js": "^11.5.1",
     "dotenv": "^8.2.0",
-    "erlpack": "github:discordapp/erlpack",
+    "erlpack": "github:hammerandchisel/erlpack",
     "escape-string-regexp": "^2.0.0",
     "moment-timezone": "^0.5.27",
     "node-schedule": "^1.3.2",


### PR DESCRIPTION
The erlpack upgrade was necessary for Node 12 compatibility.