### PR TITLE
Fix various issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -441,7 +441,18 @@ function scheduleSummaryPosting(bridges) {
 async function connectToHub(reticulumClient, discordChannels, host, hubId) {
   const reticulumCh = reticulumClient.channelForHub(hubId, serializeProfile("Hubs Bot", discordChannels));
   reticulumCh.on("connect", (timestamp, id) => { console.info(ts(`Connected to Hubs room ${hubId} with session ID ${id}.`)); });
-  const resp = (await reticulumCh.connect()).hubs[0];
+
+  let resp;
+  try {
+    resp = (await reticulumCh.connect()).hubs[0];
+  } catch(e) {
+    if (e.reason && (e.reason === "closed" || e.reason === "join_denied" || e.reason === "not_found")) {
+      await reticulumCh.close();
+    }
+
+    throw e;
+  }
+
   const stats = new HubStats();
   const presenceRollups = new PresenceRollups();
   let nRoomOccupants = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -706,10 +706,10 @@ async function start() {
         "Valid environment URLs include GLTFs, GLBs, and Spoke scene pages.\n" +
         "🦆 `!hubs stats` - Shows some summary statistics about room usage.\n" +
         "🦆 `!hubs remove` - Removes the room URL from the topic and stops bridging this Discord channel with Hubs.\n" +
-        "🦆 `!hubs notify set [datetime]` - Sets a one-time notification to notify @here to join the room at some future time.\n" +
+        "🦆 `!hubs notify set [datetime]` - Sets a one-time notification to notify `@here` to join the room at some future time.\n" +
         "🦆 `!hubs notify clear` - Removes all pending notifications.\n" +
         "🦆 `!hubs users` - Lists the users currently in the Hubs room bridged to this channel.\n\n" +
-        "See the documentation and source at https://github.com/MozillaReality/hubs-discord-bot for a more detailed reference " +
+        "See the documentation and source at <https://github.com/MozillaReality/hubs-discord-bot> for a more detailed reference " +
         "of bot functionality, including guidelines on what permissions the bot needs, what kinds of bridging the bot can do, " +
         "and more about how the bot bridges channels to rooms. You can invite the bot to your own server at https://hubs.mozilla.com/discord.";
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ moment.locale(process.env.LOCALE);
 const VERBOSE = (process.env.VERBOSE === "true");
 
 function logger(kind, msg, data) {
-  if ((kind !== "push" && kind !== "receive") || VERBOSE) {
+  if ((kind !== "push" && kind !== "receive" && msg !== "dropping outdated message") || VERBOSE) {
     console.log("Phoenix:", kind, msg, data);
   }
 }
@@ -67,7 +67,9 @@ class DiscordEventQueue {
   }
 
   _onSizeChanged() {
-    console.log(`Event queue [${this.id}] size: ${this.size}`);
+    if (this.size >= 5 || VERBOSE) {
+      console.log(`Event queue [${this.id}] size: ${this.size}`);
+    }
   }
 
   // Enqueues the given function to run as soon as no other functions are currently running.

--- a/src/index.js
+++ b/src/index.js
@@ -568,6 +568,7 @@ async function start() {
         const perms = discordCh.permissionsFor(discordClient.user);
         if (perms.has([
           discord.Permissions.FLAGS.MANAGE_MESSAGES,
+          discord.Permissions.FLAGS.VIEW_CHANNEL,
           discord.Permissions.FLAGS.READ_MESSAGES,
           discord.Permissions.FLAGS.READ_MESSAGE_HISTORY
         ])) {

--- a/src/index.js
+++ b/src/index.js
@@ -643,6 +643,7 @@ async function start() {
           } else if (newWebhook != null && (oldWebhook == null || newWebhook.id !== oldWebhook.id)) {
             await discordCh.send(`The webhook "${newWebhook.name}" (${newWebhook.id}) will now be used for bridging chat in Hubs.`);
           }
+          // eslint-disable-next-line require-atomic-updates
           ACTIVE_WEBHOOKS[discordCh.id] = newWebhook;
         } catch(e) {
           if (!(e instanceof discord.DiscordAPIError)) { // if we don't have webhook looking permissions just ignore
@@ -674,6 +675,7 @@ async function start() {
         if (currHubId != null && (prevHub == null || prevHub.id != currHubId)) {
           let currHub = connectedHubs[currHubId];
           if (currHub == null) {
+            // eslint-disable-next-line require-atomic-updates
             currHub = connectedHubs[currHubId] = await connectToHub(reticulumClient, [newChannel], currHubUrl.host, currHubId);
             await establishBridging(currHub, bridges);
             bridges.associate(currHub, newChannel);


### PR DESCRIPTION
Fixes a number of issues with the discord bot. The changes are separated in individual commits if you want to view their diffs in isolation.

- Reduce default log verbosity so that our production logs are more readable
- Stop reconnection attempts if hub is not available. This applies to hubs that are closed, set to "invite only", or for hub urls that have incorrect hub ids.
- Fix errors when iterating through restricted discord channels
- Avoid actually pinging everyone with the help message, and remove git embed (supersedes #112)
- Ignore false-positive lint errors